### PR TITLE
allow users to opt in to a code-only flow

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,6 +8,7 @@
     <div>
       <button id="button_login_responsive">Login (responsive)</button>
       <button id="button_login_redirect_query">Login (PKCE + redirect)</button>
+      <button id="button_login_redirect_code">Login (code + redirect)</button>
       <button id="button_login_redirect_query_acr_values">Login (PKCE + redirect + multiple ACR values)</button>
       <button id="button_login_redirect_query_state">Login (PKCE + redirect + state)</button>
       <button id="button_login_popup">Login (PKCE + popup)</button>
@@ -45,8 +46,15 @@
       document.getElementById('button_login_redirect_query').addEventListener('click', () => {
         criiptoAuth.redirect.authorize({
           redirectUri: 'http://localhost:8080/example/index.html',
-          acrValues: 'urn:grn:authn:dk:mitid:low',
           prompt: 'login'
+        });
+      });
+
+      document.getElementById('button_login_redirect_code').addEventListener('click', () => {
+        criiptoAuth.redirect.authorize({
+          redirectUri: 'http://localhost:8080/example/index.html',
+          prompt: 'login',
+          responseType: 'code'
         });
       });
 
@@ -83,7 +91,7 @@
       });
 
       document.getElementById('button_login_popup_code').addEventListener('click', () => {
-        criiptoAuth.popup.trigger({
+        criiptoAuth.popup.authorize({
           redirectUri: 'http://localhost:8080/example/index.html',
           prompt: 'login',
           responseType: 'code'

--- a/example/qr.html
+++ b/example/qr.html
@@ -5,7 +5,16 @@
     <link href="../src/index.css" type="text/css" rel="stylesheet" />
   </head>
   <body>
-    <div id="qrcode" style="width: 400px; height: 400px"></div>
+    <div style="display: flex; flex-flow: row; gap: 16px">
+      <div>
+        <strong>id_token response</strong>
+        <div id="qrcode_token" style="width: 400px; height: 400px"></div>
+      </div>
+      <div>
+        <strong>code response</strong>
+        <div id="qrcode_code" style="width: 400px; height: 400px"></div>
+      </div>
+    </div>
     <textarea id="result" style="width: 400px; height: 400px"></textarea>
     <script type="text/javascript">
       var criiptoAuth = new CriiptoAuth({
@@ -14,7 +23,7 @@
         store: sessionStorage
       });
 
-      criiptoAuth.qr.authorize(document.getElementById('qrcode'), {
+      criiptoAuth.qr.authorize(document.getElementById('qrcode_token'), {
 
       }).then((result) => {
         console.log(result);
@@ -22,7 +31,17 @@
       }).catch(err => {
         console.log(err);
         document.getElementById('result').innerHTML = JSON.stringify(result);
-      })
+      });
+
+      criiptoAuth.qr.authorize(document.getElementById('qrcode_code'), {
+        responseType: 'code'
+      }).then((result) => {
+        console.log(result);
+        document.getElementById('result').innerHTML = JSON.stringify(result);
+      }).catch(err => {
+        console.log(err);
+        document.getElementById('result').innerHTML = JSON.stringify(result);
+      });
     </script>
   </body>
 </html>

--- a/src/Popup.ts
+++ b/src/Popup.ts
@@ -107,13 +107,19 @@ export default class CriiptoAuthPopup {
   /*
    * Start PKCE based login flow in a popup
    */
-  authorize(params: PopupAuthorizeParams): Promise<AuthorizeResponse> {
-    return generatePKCE().then(pkce => {
-      return this.trigger({
-        ...params,
-        responseType: 'code',
-        pkce
-      });
+  async authorize(params: PopupAuthorizeParams): Promise<AuthorizeResponse> {
+    const responseType = params.responseType ?? 'id_token';
+    const pkce = await (
+      params.pkce ?
+        Promise.resolve(params.pkce) :
+        responseType === 'id_token' ?
+          generatePKCE() : Promise.resolve(undefined)
+    );
+
+    return this.trigger({
+      ...params,
+      responseType: 'code',
+      pkce
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ interface CriiptoAuthOptions {
   store: Storage;
 
   redirectUri?: string;
-  responseMode?: string;
   responseType?: ResponseType;
   acrValues?: string | string[];
   scope?: string;
@@ -219,7 +218,6 @@ export class CriiptoAuth {
 
   buildAuthorizeParams(params: AuthorizeUrlParamsOptional): AuthorizeUrlParams {
     const redirectUri = params.redirectUri || this.options.redirectUri;
-    const responseMode = params.responseMode || this.options.responseMode || 'query';
     const responseType = params.responseType || this.options.responseType || 'code';
     const acrValues = params.acrValues || this.options.acrValues;
     const scope = params.scope || this.options.scope || 'openid';
@@ -228,7 +226,7 @@ export class CriiptoAuth {
 
     return {
       redirectUri: redirectUri!,
-      responseMode: responseMode!,
+      responseMode: params.responseMode || 'query',
       responseType: responseType!,
       acrValues: acrValues,
       pkce: params.pkce,

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -28,17 +28,18 @@ export function generate() : Promise<PKCE> {
 }
 
 export const PKCE_STATE_KEY = '@criipto/verify-js:pkce:state';
-type PKCE_STATE = {redirect_uri: string, pkce_code_verifier: string};
+type PKCE_STATE = {response_type: 'id_token', redirect_uri: string, pkce_code_verifier: string};
+type RESPONSE_CODE_STATE = {response_type: 'code', redirect_uri: string};
 
-export function savePKCEState(store: Storage, input: PKCE_STATE) {
+export function savePKCEState(store: Storage, input: PKCE_STATE | RESPONSE_CODE_STATE) {
   store.setItem(PKCE_STATE_KEY, JSON.stringify(input));
 }
 
-export function getPKCEState(store: Storage) : PKCE_STATE | null {
+export function getPKCEState(store: Storage) : PKCE_STATE | RESPONSE_CODE_STATE | null {
   const state = store.getItem(PKCE_STATE_KEY);
   if (!state) return null;
 
-  return JSON.parse(state) as PKCE_STATE;
+  return JSON.parse(state) as (PKCE_STATE | RESPONSE_CODE_STATE);
 }
 
 export function clearPKCEState(store: Storage) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,12 +47,11 @@ export const ALL_VIA = ['redirect', 'popup'] as const; // TS 3.4
 type ViaTuple = typeof ALL_VIA;
 type Via = ViaTuple[number];
 
-export interface AuthorizeParams extends Partial<AuthorizeUrlParams> {
+export interface AuthorizeParams extends Partial<Omit<AuthorizeUrlParams, 'responseMode'>> {
   via: Via,
   acrValues?: string | string[];
   redirectUri?: string;
   responseType?: ResponseType;
-  responseMode?: string;
 }
 
 export interface RedirectAuthorizeParams extends Partial<AuthorizeParams> {

--- a/test/Redirect.test.ts
+++ b/test/Redirect.test.ts
@@ -168,6 +168,7 @@ describe('CriiptoAuthRedirect', () => {
       expect.assertions(1);
 
       savePKCEState(auth.store, {
+        response_type: 'id_token',
         redirect_uri: Math.random().toString(),
         pkce_code_verifier: Math.random().toString(),
       });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -342,7 +342,6 @@ describe('CriiptoAuth', () => {
       const params = {
         acrValues: Math.random().toString(),
         redirectUri: Math.random().toString(),
-        responseMode: 'fragment',
         responseType: 'id_token' as ResponseType,
         scope: Math.random().toString()
       };
@@ -358,7 +357,7 @@ describe('CriiptoAuth', () => {
 
       });
 
-      expect(actual).toStrictEqual({...params, pkce: undefined, state: undefined, loginHint: undefined, uiLocales: undefined, extraUrlParams: undefined, prompt: undefined, nonce: undefined});
+      expect(actual).toStrictEqual({...params, responseMode: "query", pkce: undefined, state: undefined, loginHint: undefined, uiLocales: undefined, extraUrlParams: undefined, prompt: undefined, nonce: undefined});
     });
 
     it('throws an error if redirectUri is not defined', () => {


### PR DESCRIPTION
Instead of always opting to do `PKCE` a user can now choose between `PKCE/id_token` or simply getting back the `code` (will be required for some pass-through flows we'll eventually build).