### PR TITLE
Update jose version to 6.2.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.3",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.5",
+        "jose": "^6.2.2",
         "qrcode": "^1.5.1"
       },
       "devDependencies": {
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "jose": "^4.15.5",
+    "jose": "^6.2.2",
     "qrcode": "^1.5.1"
   },
   "lint-staged": {


### PR DESCRIPTION
This is the latest version, and in particular it has a trusted
publisher tag, which is useful for downstream use.
